### PR TITLE
Structured Logging

### DIFF
--- a/cmd/third_rail/main.go
+++ b/cmd/third_rail/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/handlers"
@@ -27,6 +26,8 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	log.SetFormatter(&log.JSONFormatter{})
 
 	if martaClient == nil {
 		martaClient = marta_client.GetMartaClient(opts.MartaAPIKey, opts.MartaCacheTTL)
@@ -78,7 +79,7 @@ func mountAndServe(mc clients.MartaClient, tc clients.TwitterClient) {
 
 	router.PathPrefix("/swagger/").Handler(httpSwagger.WrapHandler)
 
-	fmt.Println("started on port :5000")
+	log.Info("started on port :5000")
 
 	log.Fatal(http.ListenAndServe(":5000", handlers.CORS(
 		handlers.AllowCredentials(),

--- a/pkg/clients/marta_client/client.go
+++ b/pkg/clients/marta_client/client.go
@@ -2,13 +2,14 @@ package marta_client
 
 import (
 	"encoding/xml"
+	"io/ioutil"
+	"net/http"
+	"time"
+
 	"github.com/karlseguin/ccache"
 	log "github.com/sirupsen/logrus"
 	"github.com/smartatransit/gomarta"
 	"github.com/smartatransit/third_rail/pkg/schemas/marta_schemas"
-	"io/ioutil"
-	"net/http"
-	"time"
 )
 
 const MARTA_ALERT_ENDPOINT = "https://martaalerts.com/webdata.aspx"
@@ -35,7 +36,7 @@ func GetMartaClient(apiKey string, cacheTTL int) MartaAPIClient {
 }
 
 func (m MartaAPIClient) GetTrains() (gomarta.TrainAPIResponse, error) {
-	log.Print("Fetching trains (no cache)")
+	log.Info("Fetching trains (no cache)")
 	trains, err := m.cache.Fetch("trains", time.Second*m.cacheTTL, func() (interface{}, error) {
 		return m.client.GetTrains()
 	})
@@ -50,7 +51,7 @@ func (m MartaAPIClient) GetTrains() (gomarta.TrainAPIResponse, error) {
 func (m MartaAPIClient) GetAlerts() (marta_schemas.Alerts, error) {
 
 	alerts, err := m.cache.Fetch("trains", time.Second*m.cacheTTL, func() (interface{}, error) {
-		log.Print("Fetching alerts (no cache)")
+		log.Info("Fetching alerts (no cache)")
 		resp, err := http.Get(MARTA_ALERT_ENDPOINT)
 		if err != nil {
 			log.Fatal("Error getting response. ", err)

--- a/pkg/controllers/live.go
+++ b/pkg/controllers/live.go
@@ -2,8 +2,9 @@ package controllers
 
 import (
 	"encoding/json"
-	log "github.com/sirupsen/logrus"
 	"net/http"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/gorilla/mux"
 	"github.com/smartatransit/third_rail/pkg/clients"
@@ -58,7 +59,7 @@ func (controller LiveController) GetScheduleByStation(w http.ResponseWriter, req
 	params := mux.Vars(req)
 	station := params["station"]
 
-	log.Printf("Displaying schedules for %s", station)
+	log.Infof("Displaying schedules for %s", station)
 
 	events, _ := controller.MartaClient.GetTrains()
 	mev := validators.NewMartaEntitiesValidator()

--- a/pkg/transformers/event.go
+++ b/pkg/transformers/event.go
@@ -1,11 +1,12 @@
 package transformers
 
 import (
+	"strings"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/smartatransit/gomarta"
 	"github.com/smartatransit/third_rail/pkg/schemas/marta_schemas"
 	"github.com/smartatransit/third_rail/pkg/validators"
-	"strings"
 )
 
 type EventTransformer struct {
@@ -24,7 +25,7 @@ func (et EventTransformer) GetStation(event gomarta.Train) marta_schemas.Station
 	station, err := et.MEV.Coerce(validators.MARTA_STATIONS, event.Station)
 
 	if err != nil {
-		log.Printf("Coercion miss: %s", err)
+		log.Errorf("Coercion miss: %s", err)
 	}
 
 	return marta_schemas.Station{
@@ -38,13 +39,13 @@ func (et EventTransformer) GetSchedule(event gomarta.Train) marta_schemas.Schedu
 	destination, destErr := et.MEV.Coerce(validators.MARTA_STATIONS, event.Destination)
 
 	if destErr != nil {
-		log.Printf("Coercion miss: %s", destErr)
+		log.Errorf("Coercion miss: %s", destErr)
 	}
 
 	station, statErr := et.MEV.Coerce(validators.MARTA_STATIONS, event.Station)
 
 	if statErr != nil {
-		log.Printf("Coercion miss: %s", statErr)
+		log.Errorf("Coercion miss: %s", statErr)
 	}
 
 	return marta_schemas.Schedule{


### PR DESCRIPTION
```
~/repos/third_rail on  bipol/logging! ⌚ 16:55:47
$ godotenv -f .env bin/darwin_amd64/third_rail                                                                                                                                                            ‹system›
started on port :5000
```

to
```
~/repos/third_rail on  bipol/logging! ⌚ 16:56:36
$ godotenv -f .env bin/darwin_amd64/third_rail                                                                                                                                                            ‹system›
{"level":"info","msg":"started on port :5000","time":"2020-06-15T16:57:47-04:00"}
```
------------
We already have kibana logging such that if you send a `level:alert`, we'll log it to slack!
![image](https://user-images.githubusercontent.com/3458971/84705647-bac1bb80-af29-11ea-8d91-72916daf1557.png)

It probably makes sense to change this to `error`, `panic`, and `fatal` instead, to match logrus' natural error levels.  See [logrus](https://github.com/sirupsen/logrus).