### PR TITLE
refactor a db initialization job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ COPY vendor/ vendor/
 COPY data/ data/
 COPY docs/ docs/
 COPY cmd/ cmd/
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -installsuffix cgo cmd/third_rail/main.go
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -installsuffix cgo cmd/dbinit/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -installsuffix cgo cmd/third_rail/main.go -o third_rail
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -installsuffix cgo cmd/dbinit/main.go -o dbinit
 
 FROM alpine:3.11
 RUN apk --no-cache add ca-certificates
 
-COPY --from=builder /src/main /bin/main
+COPY --from=builder /src/third_rail /bin/third_rail
 COPY --from=builder /src/dbinit /bin/dbinit
-CMD ["/bin/main"]
+CMD ["/bin/third_rail"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ COPY data/ data/
 COPY docs/ docs/
 COPY cmd/ cmd/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -installsuffix cgo cmd/third_rail/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -installsuffix cgo cmd/dbinit/main.go
 
 FROM alpine:3.11
 RUN apk --no-cache add ca-certificates
 
 COPY --from=builder /src/main /bin/main
+COPY --from=builder /src/dbinit /bin/dbinit
 CMD ["/bin/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ COPY vendor/ vendor/
 COPY data/ data/
 COPY docs/ docs/
 COPY cmd/ cmd/
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -installsuffix cgo cmd/third_rail/main.go -o third_rail
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -installsuffix cgo cmd/dbinit/main.go -o dbinit
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -installsuffix cgo -o third_rail cmd/third_rail/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -a -installsuffix cgo -o dbinit cmd/dbinit/main.go
 
 FROM alpine:3.11
 RUN apk --no-cache add ca-certificates

--- a/cmd/dbinit/main.go
+++ b/cmd/dbinit/main.go
@@ -15,8 +15,11 @@ func main() {
 	}
 
 	app := &api.App{Options: options}
+
 	if err = app.Initialize(); err != nil {
 		log.Fatal(err)
 	}
-	app.Start(nil)
+	if err = app.InitializeSchema(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/pkg/api/api_live_test.go
+++ b/pkg/api/api_live_test.go
@@ -171,7 +171,7 @@ func setUpLiveAPI(t *testing.T, martaClient clients.MartaClient) (app *App) {
 
 	app = &App{DB: db, MartaClient: martaClient}
 
-	app.Start(true, func() {
+	app.Start(func() {
 		app.Router = mux.NewRouter()
 		app.mountLiveRoutes()
 	})

--- a/pkg/api/api_smart_test.go
+++ b/pkg/api/api_smart_test.go
@@ -90,7 +90,15 @@ func setUpSmartAPI(t *testing.T, twitterClient clients.TwitterClient) (app *App)
 
 	app = &App{DB: db, TwitterClient: twitterClient}
 
-	app.Start(true, func() {
+	err = app.Initialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = app.InitializeSchema()
+	if err != nil {
+		t.Fatal(err)
+	}
+	app.Start(func() {
 		app.Router = mux.NewRouter()
 		app.mountSmartRoutes()
 	})

--- a/pkg/api/api_static_test.go
+++ b/pkg/api/api_static_test.go
@@ -109,7 +109,15 @@ func setUpStaticAPI(t *testing.T) (app *App) {
 
 	app = &App{DB: db}
 
-	app.Start(true, func() {
+	err = app.Initialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = app.InitializeSchema()
+	if err != nil {
+		t.Fatal(err)
+	}
+	app.Start(func() {
 		app.Router = mux.NewRouter()
 		app.MountStaticRoutes()
 	})

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -6,10 +6,6 @@ type Options struct {
 	MartaAPIKey         string `long:"marta-api-key" env:"MARTA_API_KEY" description:"marta api key"`
 	TwitterCacheTTL     int    `long:"twitter-cache-ttl" env:"TWITTER_CACHE_TTL" default:"15" description:"how long we keep the twitter responses" required:"true"`
 	MartaCacheTTL       int    `long:"marta-cache-ttl" env:"MARTA_CACHE_TTL" default:"15" description:"how long we keep the marta responses" required:"true"`
-	DbHost              string `long:"db-host" env:"DB_HOST" description:"the host for the smarta database"`
-	DbPort              string `long:"db-port" env:"DB_PORT" description:"the host port for the smarta database"`
-	DbName              string `long:"db-name" env:"DB_NAME" description:"the name for the smarta database"`
-	DbUsername          string `long:"db-username" env:"DB_USERNAME" description:"the username for the smarta database"`
-	DbPassword          string `long:"db-password" env:"DB_PASSWORD" description:"the password for the smarta database"`
+	DBConnectionString  string `long:"db-connection-string" env:"DB_CONNECTION_STRING"`
 	AdminAPIKey         string `long:"admin-api-key" env:"ADMIN_API_KEY" description:"admin api key"`
 }

--- a/pkg/models/migrate.go
+++ b/pkg/models/migrate.go
@@ -1,48 +1,118 @@
 package models
 
 import (
+	"fmt"
+
 	"github.com/jinzhu/gorm"
+	log "github.com/sirupsen/logrus"
 )
 
-func DBMigrate(db *gorm.DB) *gorm.DB {
-	db.LogMode(false)
+func DBMigrate(db *gorm.DB, log *log.Logger) error {
+	log.Info("Creating tables and indexes...")
 
-	db.AutoMigrate(&Direction{})
-	db.AutoMigrate(&Line{})
-	db.Table("line_directions").AddForeignKey("line_id", "lines(id)", "RESTRICT", "RESTRICT")
-	db.Table("line_directions").AddForeignKey("direction_id", "directions(id)", "RESTRICT", "RESTRICT")
+	var err error
+	if err = db.AutoMigrate(&Direction{}).Error; err != nil {
+		return fmt.Errorf("failed auto-migrating table `Direction`: %w", err)
+	}
+	if err = db.AutoMigrate(&Line{}).Error; err != nil {
+		return fmt.Errorf("failed auto-migrating table `Line`: %w", err)
+	}
 
-	db.AutoMigrate(&Station{})
-	db.AutoMigrate(&StationDetail{})
-	db.Model(&StationDetail{}).AddForeignKey("station_id", "stations(id)", "RESTRICT", "RESTRICT")
-	db.Table("station_lines").AddForeignKey("line_id", "lines(id)", "RESTRICT", "RESTRICT")
-	db.Table("station_lines").AddForeignKey("station_id", "stations(id)", "RESTRICT", "RESTRICT")
+	ldTable := db.Table("line_directions")
+	if err = ldTable.AddForeignKey("line_id", "lines(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("adding line foreign key: %w", err)
+	}
+	if err = ldTable.AddForeignKey("direction_id", "directions(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("adding direction foreign key: %w", err)
+	}
 
-	db.AutoMigrate(&Alias{})
+	if err = db.AutoMigrate(&Station{}).Error; err != nil {
+		return fmt.Errorf("failed auto-migrating table `Station`: %w", err)
+	}
+	if err = db.AutoMigrate(&StationDetail{}).Error; err != nil {
+		return fmt.Errorf("failed auto-migrating table `StationDetail`: %w", err)
+	}
+	if err = db.Model(&StationDetail{}).AddForeignKey("station_id", "stations(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("failed adding station/station-detatil foreign key: %w", err)
+	}
+	slTable := db.Table("station_lines")
+	if err = slTable.AddForeignKey("line_id", "lines(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("failed adding line-station foreign key: %w", err)
+	}
+	if err = slTable.AddForeignKey("station_id", "stations(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("failed adding station-line foreign key: %w", err)
+	}
 
-	db.AutoMigrate(&FeedbackType{})
-	db.AutoMigrate(&FeedbackSource{})
-	db.AutoMigrate(&Feedback{})
-	db.Model(&Feedback{}).AddForeignKey("source_id", "feedback_sources(id)", "RESTRICT", "RESTRICT")
-	db.Model(&Feedback{}).AddForeignKey("type_id", "feedback_types(id)", "RESTRICT", "RESTRICT")
-	db.Model(&Feedback{}).AddForeignKey("station_id", "stations(id)", "RESTRICT", "RESTRICT")
-	db.Model(&Feedback{}).AddForeignKey("line_id", "lines(id)", "RESTRICT", "RESTRICT")
-	db.Model(&Feedback{}).AddForeignKey("direction_id", "directions(id)", "RESTRICT", "RESTRICT")
+	if err = db.AutoMigrate(&Alias{}).Error; err != nil {
+		return fmt.Errorf("failed auto-migrating table `Alias`: %w", err)
+	}
+	if err = db.AutoMigrate(&FeedbackType{}).Error; err != nil {
+		return fmt.Errorf("failed auto-migrating table `FeedbackType`: %w", err)
+	}
+	if err = db.AutoMigrate(&FeedbackSource{}).Error; err != nil {
+		return fmt.Errorf("failed auto-migrating table `FeedbackSource`: %w", err)
+	}
+	if err = db.AutoMigrate(&Feedback{}).Error; err != nil {
+		return fmt.Errorf("failed auto-migrating table `Feedback`: %w", err)
+	}
 
-	db.AutoMigrate(&Train{})
+	fbModel := db.Model(&Feedback{})
+	if err = fbModel.AddForeignKey("source_id", "feedback_sources(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("failed adding feedback-source foreign key: %w", err)
+	}
+	if err = fbModel.AddForeignKey("type_id", "feedback_types(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("failed adding feedback-type foreign key: %w", err)
+	}
+	if err = fbModel.AddForeignKey("station_id", "stations(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("failed adding feedback-station foreign key: %w", err)
+	}
+	if err = fbModel.AddForeignKey("line_id", "lines(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("failed adding feedback-line foreign key: %w", err)
+	}
+	if err = fbModel.AddForeignKey("direction_id", "directions(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("failed adding feedback-direction foreign key: %w", err)
+	}
 
-	db.AutoMigrate(&ScheduleEventSource{})
-	db.AutoMigrate(&ScheduleEvent{})
-	db.Model(&ScheduleEvent{}).AddForeignKey("event_type_id", "schedule_event_sources(id)", "RESTRICT", "RESTRICT")
-	db.Model(&ScheduleEvent{}).AddForeignKey("destination_id", "stations(id)", "RESTRICT", "RESTRICT")
-	db.Model(&ScheduleEvent{}).AddForeignKey("next_station_id", "stations(id)", "RESTRICT", "RESTRICT")
+	if err = db.AutoMigrate(&Train{}).Error; err != nil {
+		return fmt.Errorf("failed auto-migrating table `Train`: %w", err)
+	}
 
-	db.AutoMigrate(&RealTimeEventDetail{})
-	db.AutoMigrate(&RealTimeEventDetail{}).AddForeignKey("schedule_event_id", "schedule_events(id)", "RESTRICT", "RESTRICT")
-	db.AutoMigrate(&RealTimeEventDetail{}).AddForeignKey("train_id", "trains(id)", "RESTRICT", "RESTRICT")
+	if err = db.AutoMigrate(&ScheduleEventSource{}).Error; err != nil {
+		return fmt.Errorf("failed auto-migrating table `ScheduleEventSource`: %w", err)
+	}
+	if err = db.AutoMigrate(&ScheduleEvent{}).Error; err != nil {
+		return fmt.Errorf("failed auto-migrating table `ScheduleEvent`: %w", err)
+	}
 
-	db.AutoMigrate(&StaticEventDetail{})
-	db.AutoMigrate(&StaticEventDetail{}).AddForeignKey("schedule_event_id", "schedule_events(id)", "RESTRICT", "RESTRICT")
+	sEvent := db.Model(&ScheduleEvent{})
+	if err = sEvent.AddForeignKey("event_type_id", "schedule_event_sources(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("failed adding schedule-event/event_type foreign key: %w", err)
+	}
+	if err = sEvent.AddForeignKey("destination_id", "stations(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("failed adding schedule-event/destination foreign key: %w", err)
+	}
+	if err = sEvent.AddForeignKey("next_station_id", "stations(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("failed adding schedule-event/next_station foreign key: %w", err)
+	}
 
-	return db.Set("gorm:auto_preload", true)
+	if err = db.AutoMigrate(&RealTimeEventDetail{}).Error; err != nil {
+		return fmt.Errorf("failed auto-migrating table `RealTimeEventDetail`: %w", err)
+	}
+
+	rtedTable := db.Model(&RealTimeEventDetail{})
+	if err = rtedTable.AddForeignKey("schedule_event_id", "schedule_events(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("failed adding real-time-event-detail/schedule_event: %w", err)
+	}
+	if err = rtedTable.AddForeignKey("train_id", "trains(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("failed adding real-time-event-detail/train: %w", err)
+	}
+
+	if err = db.AutoMigrate(&StaticEventDetail{}).Error; err != nil {
+		return fmt.Errorf("failed auto-migrating table `StaticEventDetail`: %w", err)
+	}
+	if err = db.Model(&StaticEventDetail{}).AddForeignKey("schedule_event_id", "schedule_events(id)", "RESTRICT", "RESTRICT").Error; err != nil {
+		return fmt.Errorf("failed adding static-event-detail/schedule-event foreign key: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/seed/seed.go
+++ b/pkg/seed/seed.go
@@ -1,100 +1,249 @@
 package seed
 
 import (
+	"fmt"
+
 	"github.com/jinzhu/gorm"
 	log "github.com/sirupsen/logrus"
 	"github.com/smartatransit/third_rail/pkg/models"
 )
 
-func Seed(db *gorm.DB) {
-
-	db.LogMode(false)
+func Seed(db *gorm.DB, log *log.Logger) error {
+	var err error
 
 	//Event sources
-	UpsertEventSource(db, "MARTA_StaticSchedule", "MARTA's Trip Schedule")
-	UpsertEventSource(db, "MARTA_RealTime", "MARTA's Real Time API")
+	if _, err = InsertEventSource(db, "MARTA_StaticSchedule", "MARTA's Trip Schedule"); err != nil {
+		return err
+	}
+	if _, err = InsertEventSource(db, "MARTA_RealTime", "MARTA's Real Time API"); err != nil {
+		return err
+	}
 
 	//Directions
 	log.Info("Creating Directions")
 
-	northbound := UpsertDirection(db, "Northbound", []string{"NB", "N", "North"})
-	southbound := UpsertDirection(db, "Southbound", []string{"SB", "S", "South"})
-	eastbound := UpsertDirection(db, "Eastbound", []string{"EB", "E", "East"})
-	westbound := UpsertDirection(db, "Westbound", []string{"WB", "W", "West"})
+	northbound, err := InsertDirection(db, "Northbound", []string{"NB", "N", "North"})
+	if err != nil {
+		return err
+	}
+	southbound, err := InsertDirection(db, "Southbound", []string{"SB", "S", "South"})
+	if err != nil {
+		return err
+	}
+	eastbound, err := InsertDirection(db, "Eastbound", []string{"EB", "E", "East"})
+	if err != nil {
+		return err
+	}
+	westbound, err := InsertDirection(db, "Westbound", []string{"WB", "W", "West"})
+	if err != nil {
+		return err
+	}
 
 	//Lines
 	log.Info("Creating Lines")
 
-	gold := UpsertLine(db, "Gold", []string{"Gold"}, []models.Direction{northbound, southbound})
-	red := UpsertLine(db, "Red", nil, []models.Direction{northbound, southbound})
-	blue := UpsertLine(db, "Blue", nil, []models.Direction{eastbound, westbound})
-	green := UpsertLine(db, "Green", nil, []models.Direction{eastbound, westbound})
+	gold, err := InsertLine(db, "Gold", []string{"Gold"}, []models.Direction{northbound, southbound})
+	if err != nil {
+		return err
+	}
+	red, err := InsertLine(db, "Red", nil, []models.Direction{northbound, southbound})
+	if err != nil {
+		return err
+	}
+	blue, err := InsertLine(db, "Blue", nil, []models.Direction{eastbound, westbound})
+	if err != nil {
+		return err
+	}
+	green, err := InsertLine(db, "Green", nil, []models.Direction{eastbound, westbound})
+	if err != nil {
+		return err
+	}
 
 	//Stations
 	log.Info("Creating Stations")
 
 	//Gold
-	_ = UpsertStation(db, "Doraville", "dnh0f5v6mxzj", "Doraville Station", nil, []models.Line{gold})
-	_ = UpsertStation(db, "Chamblee", "dnh0c94gqrm2", "Chamblee Station", nil, []models.Line{gold})
-	_ = UpsertStation(db, "Brookhaven", "dnh08u1fpng1", "Brookhaven Station", []string{"Brookhaven-Oglethorpe Station"}, []models.Line{gold})
-	_ = UpsertStation(db, "Lenox", "dnh0837g7frm", "Lenox Station", nil, []models.Line{gold})
+	_, err = InsertStation(db, "Doraville", "dnh0f5v6mxzj", "Doraville Station", nil, []models.Line{gold})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Chamblee", "dnh0c94gqrm2", "Chamblee Station", nil, []models.Line{gold})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Brookhaven", "dnh08u1fpng1", "Brookhaven Station", []string{"Brookhaven-Oglethorpe Station"}, []models.Line{gold})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Lenox", "dnh0837g7frm", "Lenox Station", nil, []models.Line{gold})
+	if err != nil {
+		return err
+	}
 
 	//Red
-	_ = UpsertStation(db, "North Springs", "dnh107scwx23", "North Springs Station", nil, []models.Line{red})
-	_ = UpsertStation(db, "Sandy Springs", "dnh10939s87f", "Sandy Springs Station", nil, []models.Line{red})
-	_ = UpsertStation(db, "Dunwoody", "dnh0bxnr3hcj", "Dunwoody Station", nil, []models.Line{red})
-	_ = UpsertStation(db, "Medical Center", "dnh0bt32f0zr", "Medical Center Station", nil, []models.Line{red})
-	_ = UpsertStation(db, "Buckhead", "dnh084sbc4fj", "Buckhead Station", nil, []models.Line{red})
+	_, err = InsertStation(db, "North Springs", "dnh107scwx23", "North Springs Station", nil, []models.Line{red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Sandy Springs", "dnh10939s87f", "Sandy Springs Station", nil, []models.Line{red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Dunwoody", "dnh0bxnr3hcj", "Dunwoody Station", nil, []models.Line{red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Medical Center", "dnh0bt32f0zr", "Medical Center Station", nil, []models.Line{red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Buckhead", "dnh084sbc4fj", "Buckhead Station", nil, []models.Line{red})
+	if err != nil {
+		return err
+	}
 
 	//Blue
-	_ = UpsertStation(db, "Indian Creek", "dnh0579u6fcg", "Indian Creek Station", nil, []models.Line{blue})
-	_ = UpsertStation(db, "Kensington", "dnh04u1s7ycg", "Kensington Station", nil, []models.Line{blue})
-	_ = UpsertStation(db, "Avondale", "dnh04heebfzp", "Avondale Station", nil, []models.Line{blue})
-	_ = UpsertStation(db, "Decatur", "dnh01u9cru4h", "Decatur Station", nil, []models.Line{blue})
-	_ = UpsertStation(db, "East Lake", "dnh016v1ynv9", "East Lake Station", nil, []models.Line{blue})
-	_ = UpsertStation(db, "West Lake", "dn5bn2sgc1bc", "West Lake Station", nil, []models.Line{blue})
-	_ = UpsertStation(db, "H. E. Holmes", "dn5bjbfgcmr3", "Hamilton E. Holmes Station", []string{"Hamilton E. Holmes", "Hamilton E Holmes", "Hamilton E Holmes Station"}, []models.Line{blue})
+	_, err = InsertStation(db, "Indian Creek", "dnh0579u6fcg", "Indian Creek Station", nil, []models.Line{blue})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Kensington", "dnh04u1s7ycg", "Kensington Station", nil, []models.Line{blue})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Avondale", "dnh04heebfzp", "Avondale Station", nil, []models.Line{blue})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Decatur", "dnh01u9cru4h", "Decatur Station", nil, []models.Line{blue})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "East Lake", "dnh016v1ynv9", "East Lake Station", nil, []models.Line{blue})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "West Lake", "dn5bn2sgc1bc", "West Lake Station", nil, []models.Line{blue})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "H. E. Holmes", "dn5bjbfgcmr3", "Hamilton E. Holmes Station", []string{"Hamilton E. Holmes", "Hamilton E Holmes", "Hamilton E Holmes Station"}, []models.Line{blue})
+	if err != nil {
+		return err
+	}
 
 	//Green
-	_ = UpsertStation(db, "Bankhead", "dn5bnu0epkt1", "Bankhead Station", nil, []models.Line{green})
+	_, err = InsertStation(db, "Bankhead", "dn5bnu0ejdq9", "Bankhead Station", nil, []models.Line{green})
+	if err != nil {
+		return err
+	}
 
 	//Multi-line
-	_ = UpsertStation(db, "Lindbergh Center", "dn5bnu0epkt1", "Lindbergh Center Station", []string{"Lindbergh", "Lindbergh Station"}, []models.Line{gold, red})
-	_ = UpsertStation(db, "Arts Center", "dn5bnu0epkt1", "Arts Center Station", nil, []models.Line{gold, red})
-	_ = UpsertStation(db, "Midtown", "dn5bptxy8r41", "Midtown Station", nil, []models.Line{gold, red})
-	_ = UpsertStation(db, "North Avenue", "dn5bpsp70th7", "North Avenue Station", []string{"North Ave", "North Ave Station"}, []models.Line{gold, red})
-	_ = UpsertStation(db, "Civic Center", "dn5bpep496h7", "Civic Center Station", nil, []models.Line{gold, red})
-	_ = UpsertStation(db, "Peachtree Center", "dn5bp9qxs9nh", "Peachtree Center Station", nil, []models.Line{gold, red})
-	_ = UpsertStation(db, "Five Points", "dn5bp8ezwy4k", "Five Points Station", []string{"5 points"}, []models.Line{gold, red, blue, green})
-	_ = UpsertStation(db, "Garnett", "djgzzxbb2xkd", "Garnett Station", nil, []models.Line{gold, red})
-	_ = UpsertStation(db, "West End", "djgzzjeb581t", "West End Station", nil, []models.Line{gold, red})
-	_ = UpsertStation(db, "Oakland City", "djgzyf5dfsmn", "Oakland City Station", []string{"Oakland"}, []models.Line{gold, red})
-	_ = UpsertStation(db, "Lakewood", "djgzwz0c6suf", "Lakewood/Fort McPherson Station", []string{"Lakewood", "Lakewood Station", "Ft. Mcpherson"}, []models.Line{gold, red})
-	_ = UpsertStation(db, "East Point", "djgzwdb63g2k", "East Point Station", nil, []models.Line{gold, red})
-	_ = UpsertStation(db, "College Park", "djgzqq4k3j73", "College Park Station", nil, []models.Line{gold, red})
-	_ = UpsertStation(db, "Airport", "djgzqkhjse84", "Airport Station", nil, []models.Line{gold, red})
-	_ = UpsertStation(db, "Ashby", "dn5bp11qp0s9", "Ashby Station", nil, []models.Line{blue, green})
-	_ = UpsertStation(db, "Vine City", "dn5bp34zmh5s", "Vine City Station", nil, []models.Line{blue, green})
-	_ = UpsertStation(db, "Omni Dome", "dn5bp90pezjh", "Omni/Dome/GWCC/State Farm/CNN Center Station", []string{"Omni", "Omni Dome", "Omni Dome Station", "Georgia Dome", "CNN", "State Farm Arena", "Phillips Arena", "Georgia World Congress"}, []models.Line{blue, green})
-	_ = UpsertStation(db, "Georgia State", "dn5bp8pgdtcf", "Georgia State Station", []string{"GSU"}, []models.Line{blue, green})
-	_ = UpsertStation(db, "King Memorial", "dn5bpbp8fe6s", "King Memorial Station", []string{"MLK"}, []models.Line{blue, green})
-	_ = UpsertStation(db, "Inman Park", "dnh0092w0nxh", "Inman Park-Reynoldstown Station", []string{"Inman Park Station", "Reynoldstown"}, []models.Line{blue, green})
-	_ = UpsertStation(db, "Edgewood-Candler Park", "dnh00f1wzrc6", "Edgewood-Candler Park Station", []string{"Edgewood", "Candler", "Edgewood Candler Park", "Edgewood Candler Park Station"}, []models.Line{blue, green})
+	_, err = InsertStation(db, "Lindbergh Center", "dnh02jhnbebq", "Lindbergh Center Station", []string{"Lindbergh", "Lindbergh Station"}, []models.Line{gold, red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Arts Center", "dn5bpxphcqh3", "Arts Center Station", nil, []models.Line{gold, red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Midtown", "dn5bptxy8r41", "Midtown Station", nil, []models.Line{gold, red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "North Avenue", "dn5bpsp70th7", "North Avenue Station", []string{"North Ave", "North Ave Station"}, []models.Line{gold, red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Civic Center", "dn5bpep496h7", "Civic Center Station", nil, []models.Line{gold, red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Peachtree Center", "dn5bp9qxs9nh", "Peachtree Center Station", nil, []models.Line{gold, red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Five Points", "dn5bp8ezwy4k", "Five Points Station", []string{"5 points"}, []models.Line{gold, red, blue, green})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Garnett", "djgzzxbb2xkd", "Garnett Station", nil, []models.Line{gold, red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "West End", "djgzzjeb581t", "West End Station", nil, []models.Line{gold, red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Oakland City", "djgzyf5dfsmn", "Oakland City Station", []string{"Oakland"}, []models.Line{gold, red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Lakewood", "djgzwz0c6suf", "Lakewood/Fort McPherson Station", []string{"Lakewood", "Lakewood Station", "Ft. Mcpherson"}, []models.Line{gold, red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "East Point", "djgzwdb63g2k", "East Point Station", nil, []models.Line{gold, red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "College Park", "djgzqq4k3j73", "College Park Station", nil, []models.Line{gold, red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Airport", "djgzqkhjse84", "Airport Station", nil, []models.Line{gold, red})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Ashby", "dn5bp11qp0s9", "Ashby Station", nil, []models.Line{blue, green})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Vine City", "dn5bp34zmh5s", "Vine City Station", nil, []models.Line{blue, green})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Omni Dome", "dn5bp90pezjh", "Omni/Dome/GWCC/State Farm/CNN Center Station", []string{"Omni", "Omni Dome", "Omni Dome Station", "Georgia Dome", "CNN", "State Farm Arena", "Phillips Arena", "Georgia World Congress"}, []models.Line{blue, green})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Georgia State", "dn5bp8pgdtcf", "Georgia State Station", []string{"GSU"}, []models.Line{blue, green})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "King Memorial", "dn5bpbp8fe6s", "King Memorial Station", []string{"MLK"}, []models.Line{blue, green})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Inman Park", "dnh0092w0nxh", "Inman Park-Reynoldstown Station", []string{"Inman Park Station", "Reynoldstown"}, []models.Line{blue, green})
+	if err != nil {
+		return err
+	}
+	_, err = InsertStation(db, "Edgewood-Candler Park", "dnh00f1wzrc6", "Edgewood-Candler Park Station", []string{"Edgewood", "Candler", "Edgewood Candler Park", "Edgewood Candler Park Station"}, []models.Line{blue, green})
+	if err != nil {
+		return err
+	}
 
+	return nil
 }
 
-func UpsertEventSource(db *gorm.DB, name, description string) models.ScheduleEventSource {
+func InsertEventSource(db *gorm.DB, name, description string) (models.ScheduleEventSource, error) {
+	var err error
 	var eventSource models.ScheduleEventSource
 
-	db.FirstOrCreate(&eventSource, &models.ScheduleEventSource{
+	err = db.FirstOrCreate(&eventSource, &models.ScheduleEventSource{
 		Name:        name,
 		Description: description,
-	})
+	}).Error
+	if err != nil {
+		return eventSource, fmt.Errorf("failed creating event source `%s`: %w", name, err)
+	}
 
-	return eventSource
+	return eventSource, nil
 }
 
-func UpsertDirection(db *gorm.DB, name string, aliases []string) models.Direction {
+func InsertDirection(db *gorm.DB, name string, aliases []string) (models.Direction, error) {
+	var err error
 	direction := models.Direction{Name: name}
 
 	if aliases != nil {
@@ -107,12 +256,16 @@ func UpsertDirection(db *gorm.DB, name string, aliases []string) models.Directio
 		direction.Aliases = namedAliases
 	}
 
-	db.Save(&direction)
+	err = db.Save(&direction).Error
+	if err != nil {
+		return direction, fmt.Errorf("failed creating direction `%s`: %w", name, err)
+	}
 
-	return direction
+	return direction, nil
 }
 
-func UpsertLine(db *gorm.DB, name string, aliases []string, directions []models.Direction) models.Line {
+func InsertLine(db *gorm.DB, name string, aliases []string, directions []models.Direction) (models.Line, error) {
+	var err error
 	line := models.Line{Name: name}
 
 	if aliases != nil {
@@ -125,13 +278,20 @@ func UpsertLine(db *gorm.DB, name string, aliases []string, directions []models.
 		line.Aliases = namedAliases
 	}
 
-	db.Save(&line)
-	db.Model(&line).Association("Directions").Append(directions)
+	err = db.Save(&line).Error
+	if err != nil {
+		return line, err
+	}
+	err = db.Model(&line).Association("Directions").Append(directions).Error
+	if err != nil {
+		return line, err
+	}
 
-	return line
+	return line, nil
 }
 
-func UpsertStation(db *gorm.DB, name, location, description string, aliases []string, lines []models.Line) models.Station {
+func InsertStation(db *gorm.DB, name, location, description string, aliases []string, lines []models.Line) (models.Station, error) {
+	var err error
 	var station models.Station
 
 	if aliases != nil {
@@ -152,9 +312,15 @@ func UpsertStation(db *gorm.DB, name, location, description string, aliases []st
 		}
 	}
 
-	db.Save(&station)
+	err = db.Save(&station).Error
+	if err != nil {
+		return station, fmt.Errorf("failed creating station `%s`: %w", name, err)
+	}
 
-	db.Model(&station).Association("Lines").Append(lines)
+	err = db.Model(&station).Association("Lines").Append(lines).Error
+	if err != nil {
+		return station, fmt.Errorf("failed creating station `%s`: %w", name, err)
+	}
 
 	stationDetail := models.StationDetail{
 		StationID:   station.ID,
@@ -162,7 +328,10 @@ func UpsertStation(db *gorm.DB, name, location, description string, aliases []st
 		Location:    location,
 	}
 
-	db.Save(&stationDetail)
+	err = db.Save(&stationDetail).Error
+	if err != nil {
+		return station, fmt.Errorf("failed creating station `%s`: %w", name, err)
+	}
 
-	return station
+	return station, nil
 }


### PR DESCRIPTION
1. Refactored the `App` type to disentangle the operations needed by the API entrypoint from those needed by the initdb entrypoint
2. Added error handling to the `DBMigrate` and `DBSeed` functions
3. Fixed a couple of mis-matched geohashes for stations

This also brought to light one issue that should be written up and tracked separately: some tests were written to use an in-memory sqlite database, but sqlite doesn't support the full range of postgres constraints that our models use. These tests were failing silently before because we weren't error checking in our migration function. This could be cured by:
1. [Using sqlmock](https://medium.com/better-programming/how-to-unit-test-a-gorm-application-with-sqlmock-97ee73e36526)
2. Configuring circle to run a little PG server in our test pipeline and testing against that instead of the in-memory SQLite guy

I started tinkering with that and then decided that it's probably better left for another PR